### PR TITLE
added excludeTypes prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "autosuggest-highlight": "^3.1.0",
     "downshift": "^1.22.5",
+    "lodash.intersection": "^4.4.0",
     "prop-types": "^15.7.2",
     "react-popper": "^0.8.3"
   },

--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import _intersection from 'lodash/_intersection'
 import Grow from '@material-ui/core/Grow'
 import MenuList from '@material-ui/core/MenuList'
 import MenuItem from '@material-ui/core/MenuItem'
@@ -9,7 +10,6 @@ import Downshift from 'downshift'
 import { Manager, Target, Popper } from 'react-popper'
 import match from 'autosuggest-highlight/match'
 import parse from 'autosuggest-highlight/parse'
-
 import googleLogo from './images/google-logo-on-white-bg.png'
 
 export default class MUIPlacesAutocomplete extends React.Component {
@@ -191,7 +191,7 @@ export default class MUIPlacesAutocomplete extends React.Component {
       return
     }
 
-    const { createAutocompleteRequest } = this.props
+    const { createAutocompleteRequest, excludeTypes = null } = this.props
 
     this.autocompleteService.getPlacePredictions(
       createAutocompleteRequest(inputValue),
@@ -203,7 +203,11 @@ export default class MUIPlacesAutocomplete extends React.Component {
           return
         }
 
-        this.setState({ suggestions: predictions })
+        const predictionsToRender = excludeTypes
+          ? predictions.filter(prediction => _intersection(prediction.types, excludeTypes).length <= 0)
+          : predictions
+
+        this.setState({ suggestions: predictionsToRender })
       },
     )
   }


### PR DESCRIPTION
Added excludeTypes prop to exclude suggestions based on places api/place types - https://developers.google.com/places/web-service/autocomplete\#place_types ... defaults to all suggestions returned from original places api response.

see screenshots: restricting states and countries

<img width="813" alt="Screen Shot 2020-04-15 at 1 56 08 PM" src="https://user-images.githubusercontent.com/45948384/79387704-00a9d580-7f21-11ea-9634-4998d81f5fba.png">
<img width="775" alt="Screen Shot 2020-04-15 at 1 56 16 PM" src="https://user-images.githubusercontent.com/45948384/79387706-01426c00-7f21-11ea-8bf8-2e950ce47df3.png">
<img width="775" alt="Screen Shot 2020-04-15 at 1 55 59 PM" src="https://user-images.githubusercontent.com/45948384/79387721-056e8980-7f21-11ea-8bab-242716596624.png">
<img width="747" alt="Screen Shot 2020-04-15 at 1 55 53 PM" src="https://user-images.githubusercontent.com/45948384/79387722-056e8980-7f21-11ea-9163-c2ae200f0cb5.png">
<img width="852" alt="Screen Shot 2020-04-15 at 1 58 53 PM" src="https://user-images.githubusercontent.com/45948384/79387900-49fa2500-7f21-11ea-951b-30ef758f4a5f.png">
<img width="852" alt="Screen Shot 2020-04-15 at 1 58 53 PM" src="https://user-images.githubusercontent.com/45948384/79388095-99405580-7f21-11ea-8bcb-7f6f4d3d3a5f.png">
